### PR TITLE
Added version code to be compatible with HA 2021.6

### DIFF
--- a/custom_components/ha-lta/manifest.json
+++ b/custom_components/ha-lta/manifest.json
@@ -12,5 +12,6 @@
   "dependencies": [],
   "codeowners": [
     "@Codestian"
-  ]
+  ],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Home Assistant 2021.6 require a version key.

https://www.home-assistant.io/blog/2021/06/02/release-20216/